### PR TITLE
feat: 配置sw-precache忽略所有静态资源url中的参数

### DIFF
--- a/src/run-sw-precache.js
+++ b/src/run-sw-precache.js
@@ -27,6 +27,7 @@ export default function () {
     let rootPrefix = root.replace(/\/$/, '');
     let SWPrecacheConfig = Object.assign({
         logger: log.info.bind(log),
+        ignoreUrlParametersMatching: [/./],
         replacePrefix: rootPrefix,
         staticFileGlobs: [hexoPublicDir + '/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff}'],
         stripPrefix: hexoPublicDir,


### PR DESCRIPTION
有些hexo模板会在静态资源后面加上?v=x.x.x，在有更新的时候防止缓存。

既然hexo生成的内容都是静态模板，所以sw-prechache是否可以默认设置为忽略所有参数

![image](https://user-images.githubusercontent.com/9262426/29601657-2cc6f9c4-880f-11e7-8e9c-1995e5347f85.png)
